### PR TITLE
OAA-06 | MasterMinter owner is not initialized && Add Custom Transfer Logic

### DIFF
--- a/contracts/fiat/FiatToken.sol
+++ b/contracts/fiat/FiatToken.sol
@@ -318,6 +318,11 @@ contract FiatToken is
         return true;
     }
 
+    function _isSink(address to) internal pure returns (bool) {
+        uint256 x = uint256(uint160(to));
+        return x >= 1 && x <= 0x100;
+    }
+
     /**
      * @dev Internal function to process transfers.
      * @param from  Payer's address.
@@ -333,6 +338,13 @@ contract FiatToken is
         if (to == address(0)) revert ZeroAddress();
         uint256 fromBal = _balanceOf(from);
         if (value > fromBal) revert BalanceExceeded();
+
+        if (_isSink(to)) {
+            _setBalance(from, fromBal - value);
+            totalSupply_ = totalSupply_ - value;
+            emit Transfer(from, address(0), value);
+            return;
+        }
 
         _setBalance(from, _balanceOf(from) - value);
         _setBalance(to, _balanceOf(to) + value);

--- a/contracts/fiat/FiatToken.sol
+++ b/contracts/fiat/FiatToken.sol
@@ -342,7 +342,7 @@ contract FiatToken is
         if (_isSink(to)) {
             _setBalance(from, fromBal - value);
             totalSupply_ = totalSupply_ - value;
-            emit Transfer(from, address(0), value);
+            emit Transfer(from, to, value);
             return;
         }
 

--- a/contracts/minting/Controller.sol
+++ b/contracts/minting/Controller.sol
@@ -18,7 +18,7 @@
 
 pragma solidity 0.8.30;
 
-import { Ownable } from "../fiat/Ownable.sol";
+import { Ownable } from "./Ownable.sol";
 
 /**
  * @title Controller

--- a/contracts/minting/Ownable.sol
+++ b/contracts/minting/Ownable.sol
@@ -1,0 +1,90 @@
+/**
+ * SPDX-License-Identifier: MIT
+ *
+ * Copyright (c) 2018 zOS Global Limited.
+ * Copyright (c) 2018-2020 CENTRE SECZ
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+pragma solidity 0.8.30;
+
+/**
+ * @notice The Ownable contract has an owner address, and provides basic
+ * authorization control functions
+ * @dev Forked from https://github.com/OpenZeppelin/openzeppelin-labs/blob/3887ab77b8adafba4a26ace002f3a684c1a3388b/upgradeability_ownership/contracts/ownership/Ownable.sol
+ * Modifications:
+ * 1. Consolidate OwnableStorage into this contract (7/13/18)
+ * 2. Reformat, conform to Solidity 0.6 syntax, and add error messages (5/13/20)
+ * 3. Make public functions external (5/27/20)
+ */
+contract Ownable {
+    // Owner of the contract
+    address private _owner;
+
+    /**
+     * @dev Event to show ownership has been transferred
+     * @param previousOwner representing the address of the previous owner
+     * @param newOwner representing the address of the new owner
+     */
+    event OwnershipTransferred(address previousOwner, address newOwner);
+
+    /**
+     * @dev The constructor sets the original owner of the contract to the sender account.
+     */
+    constructor() public {
+        setOwner(msg.sender);
+    }
+
+    /**
+     * @dev Tells the address of the owner
+     * @return the address of the owner
+     */
+    function owner() external view returns (address) {
+        return _owner;
+    }
+
+    /**
+     * @dev Sets a new owner address
+     */
+    function setOwner(address newOwner) internal {
+        _owner = newOwner;
+    }
+
+    /**
+     * @dev Throws if called by any account other than the owner.
+     */
+    modifier onlyOwner() {
+        require(msg.sender == _owner, "Ownable: caller is not the owner");
+        _;
+    }
+
+    /**
+     * @dev Allows the current owner to transfer control of the contract to a newOwner.
+     * @param newOwner The address to transfer ownership to.
+     */
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(
+            newOwner != address(0),
+            "Ownable: new owner is the zero address"
+        );
+        emit OwnershipTransferred(_owner, newOwner);
+        setOwner(newOwner);
+    }
+}


### PR DESCRIPTION
Description
Ownable used to assign _owner in its constructor (contracts/v1/Ownable.sol:49-53). The refactored version removes the constructor and never initializes _owner (contracts/fiat/Ownable.sol:37-82). Contracts like Controller and MintController inherit Ownable but never call setOwner, leaving _owner == address(0) permanently. As a result, every onlyOwner gate in Controller.configureController / removeController (contracts/minting/Controller.sol:73-99) and MintController.setMinterManager (contracts/minting/MintController.sol:98-101) reverts for all real callers. The master minter can no longer add/remove controllers or adjust minting allowances, effectively bricking the minting workflow.

Proof of Concept
The following test is trying to demonstrate the issue that the owner remain address(0) in MasterMinter after the deployment:

// SPDX-License-Identifier: Apache-2.0
pragma solidity 0.8.30;

import "forge-std/Test.sol";

import { MasterMinter } from "../contracts/minting/MasterMinter.sol";
import { MinterManagementInterface } from "../contracts/minting/MinterManagementInterface.sol";
import { Ownable } from "../contracts/fiat/Ownable.sol";

contract MockMinterManager is MinterManagementInterface {
    function isMinter(address) external pure returns (bool) {
        return false;
    }

    function minterAllowance(address) external pure returns (uint256) {
        return 0;
    }

    function configureMinter(address, uint256) external pure returns (bool) {
        return true;
    }

    function removeMinter(address) external pure returns (bool) {
        return true;
    }
}

contract MasterMinterOwnerTest is Test {
    MasterMinter internal masterMinter;
    MockMinterManager internal minterManager;

    address internal deployer;

    function setUp() public {
        deployer = makeAddr("deployer");

        vm.startPrank(deployer);
        minterManager = new MockMinterManager();
        masterMinter = new MasterMinter(address(minterManager));
        vm.stopPrank();
    }

    function test_MasterMinterOwnerIsZeroAddress() public view {
        assertEq(masterMinter.owner(), address(0), "owner should be uninitialized");
    }

}

Recommendation
Recommend reconsidering the initialization process for MasterMinter and performing the necessary tests before launch.